### PR TITLE
Added qbox.lua

### DIFF
--- a/server/frameworks/qbox.lua
+++ b/server/frameworks/qbox.lua
@@ -1,0 +1,8 @@
+local FW = {}
+local QB = exports["qb-core"]:GetCoreObject()
+
+function FW.GetIdentifier(source)
+    return QB.Functions.GetPlayer(source)?.PlayerData.citizenid
+end
+
+return FW


### PR DESCRIPTION
Added qbox.lua.

Unsure if 
```lua
function FW.RegisterUsableItem(func)
    QB.Functions.CreateUseableItem(Config.SimCard.ItemName, function (source)
    	local Player = QB.Functions.GetPlayer(source)
        exports['qb-inventory']:RemoveItem(Player.PlayerData.citizenid, Config.SimCard.ItemName, 1)
        func(source)
    end)
end
```

needs to be there due to the fact that qbox uses OX as default.

Eiterway it's removed for now.

### Pull Request Description

<!-- Describe briefly what your pull request achieves or modifies -->

## Major Changes

<!--
List the main changes of the pull request
- Added reverse compatibility to X
- Fixed a rare occurence of UI lag
-->

## Modifications done
- [x] 🍃 New Feature
- [ ] ♻️ Refactor
- [ ] 🐛 Bug Fix
- [ ] 🎨 Design
- [ ] 🔥 Optimization
- [ ] 🎒 Other
